### PR TITLE
logrotate: remove rotate prop from webtop-dav config

### DIFF
--- a/webtop-dav
+++ b/webtop-dav
@@ -1,7 +1,6 @@
 /var/log/webtop-dav/*.log {
     copytruncate
     weekly
-    rotate 52
     compress
     missingok
     create 0644 apache apache


### PR DESCRIPTION
The configuration will be inherited from logrotate.conf which is controlled
by logrotate{Times} prop.

NethServer/dev#5516